### PR TITLE
spec: include JCharset 2.0 jar in rpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
         -e STAGES_PACK
         -e UPLOAD_DEST
         "
+install:
+    - ./prep-sources
 
 script: >
     docker run -ti --name makerpms ${EVARS}

--- a/nethserver-webtop5.spec
+++ b/nethserver-webtop5.spec
@@ -6,6 +6,7 @@ License: GPL
 URL: %{url_prefix}/%{name} 
 Source0: %{name}-%{version}.tar.gz
 Source4: ListTimeZones.java
+Source5: jcharset-2.0.jar
 BuildArch: noarch
 
 Requires: nethserver-mail-server, nethserver-postgresql, nethserver-httpd
@@ -22,7 +23,7 @@ BuildRequires: nethserver-devtools
 NethServer webtop configuration
 
 %prep
-%setup
+%setup -q
 
 %build
 %{makedocs}
@@ -47,6 +48,9 @@ do
     javac root/usr/share/webtop/$source
     rm -f root/usr/share/webtop/$source
 done
+
+mkdir -p root/usr/lib/jvm/jre/lib/ext
+cp %{SOURCE5} root/usr/lib/jvm/jre/lib/ext
 
 %install
 rm -rf %{buildroot}

--- a/prep-sources
+++ b/prep-sources
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -Ss -O https://www.freeutils.net/source/jcharset/jcharset-2.0-distribution.zip || exit 1
+
+unzip jcharset-2.0-distribution.zip || exit 1
+
+cp jcharset-2.0/lib/jcharset-2.0.jar . || exit 1


### PR DESCRIPTION
Download and install JCharset 2.0 library from
https://www.freeutils.net/source/jcharset/, it's need for support utf-7
char set.

NethServer/dev#5571