### PR TITLE
webtop5 restore: change field `procpid` to `pid`

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-webtop5-restore
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-restore
@@ -5,7 +5,7 @@ if [ -f /var/lib/nethserver/webtop/backup/webtop.sql ]; then
     chown postgres:postgres $drop_sql
     # drop all existing connections to the db and block new ones
     echo "UPDATE pg_database SET datallowconn = 'false' WHERE datname = 'webtop5';" >> $drop_sql
-    echo "SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE datname = 'webtop5';" >> $drop_sql
+    echo "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'webtop5';" >> $drop_sql
     # drop the db, then recreate it
     echo "DROP DATABASE webtop5;" >> $drop_sql
     password=`perl -e "use NethServer::Password; print NethServer::Password::store('webtop5');"`


### PR DESCRIPTION
From Postgresql 9.2 the field `procpid` is renamed to `pid`.
The incorrect use of the field prevent the database to be dropped during
the restore procedure, causing a inconsistent and incorrect restoration
of the webtop database.

ref:

* https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=4f42b546fd87a80be30c53a0f2c897acb826ad52