### PR TITLE
z-push: use DefaultTimezone prop for set time zone

### DIFF
--- a/root/etc/e-smith/templates/usr/share/webtop/z-push/backend/webtop/config.php/30options
+++ b/root/etc/e-smith/templates/usr/share/webtop/z-push/backend/webtop/config.php/30options
@@ -1,4 +1,4 @@
-define('TIMEZONE', '{{ $php{'DateTimezone'} }}');
+define('TIMEZONE', '{{ $webtop{'DefaultTimezone'} || 'UTC' }}');
 define('LOGBASE_DIR','/var/log/z-push/');
 define('STATEBASE_DIR', LOGBASE_DIR );
 define('STATE_DIR', STATEBASE_DIR . 'state/');


### PR DESCRIPTION
Use local webtop DefaultTimezone prop instead of global php Timezone.

NethServer/dev#5666