### PR TITLE
Revert "z-push: use DefaultTimezone prop for set time zone"

### DIFF
--- a/root/etc/e-smith/templates/usr/share/webtop/z-push/backend/webtop/config.php/30options
+++ b/root/etc/e-smith/templates/usr/share/webtop/z-push/backend/webtop/config.php/30options
@@ -1,4 +1,4 @@
-define('TIMEZONE', '{{ $webtop{'DefaultTimezone'} || 'UTC' }}');
+define('TIMEZONE', '{{ $php{'DateTimezone'} }}');
 define('LOGBASE_DIR','/var/log/z-push/');
 define('STATEBASE_DIR', LOGBASE_DIR );
 define('STATE_DIR', STATEBASE_DIR . 'state/');


### PR DESCRIPTION
This reverts commit c4594608412430efb31418ea1e7fc6c2a2b502f2.

The time zone of z-push must be aligned with system time zone.