### PR TITLE
nethserver-webtop5-conf: fix action always failed

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf
@@ -80,5 +80,5 @@ fi
 
 
 # Make sure old tomcat instance has been stopped
-systemctl stop tomcat@webtop 2>/dev/null
-config delete tomcat@webtop 2>/dev/null
+systemctl stop tomcat@webtop 2>/dev/null || exit 0
+config delete tomcat@webtop 2>/dev/null || exit 0


### PR DESCRIPTION
Make sure that the action nethserver-webtop5-conf not fail when try to
stop and remove a old tomcat@webtop instance.