### PR TITLE
pst2webtop_cal: insert value in the href field

### DIFF
--- a/root/usr/share/webtop/doc/pst2webtop_cal.php
+++ b/root/usr/share/webtop/doc/pst2webtop_cal.php
@@ -155,6 +155,7 @@ if ($tzrow[0] != "")
             $id = getGlobalKey();
             $arrayEvent["event_id"] = $id;
             $arrayEvent["public_uid"] = uniqid();
+	    $arrayEvent["href"]=$arrayEvent["public_uid"].".ics";
             $arrayEvent["read_only"] = false;
 	    echo "Importing $subject on Calendar $foldername ($user) ".$event['DTSTART']." $fromtime offset $timeOffset ....";
 	    if (!$dryrun) {


### PR DESCRIPTION
if the href field is empty, the event is not synchronized via CalDAV
NethServer/dev#5709