### PR TITLE
tomcat: explict include of jcharset in Classpath

### DIFF
--- a/root/var/lib/tomcats/webtop/bin/setenv.sh
+++ b/root/var/lib/tomcats/webtop/bin/setenv.sh
@@ -1,0 +1,1 @@
+CLASSPATH=$CATALINA_BASE/lib/jcharset-2.0.jar


### PR DESCRIPTION
The jcharset library will loaded only if included `jre/lib/ext` extension directory
or in the container's classpath. 

From lib's README.txt:
> Note: Some web/mail containers run each application in its own JVM context.
    In this case check the container documentation for information on where and
    how to configure the classpath, such as in WEB-INF/lib, shared/lib,
    jre/lib/ext, etc. You may need to restart the server for changes to take
    effect. However, if you use Oracle's JRE, it will work only if you put it in
    the jre/lib/ext extension directory, or in the container's classpath.
    This is due to a bug in Oracle's JRE implementation
    (http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4619777).


NethServer/dev#5770