### PR TITLE
db: change SMTP port if starttls is disabled

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
@@ -188,10 +188,13 @@ print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\"
 
 #set SMTP STARTTLS (default false)
 my $smtp_starttls = $db->get_prop('webtop','SmtpStarttls') || "disabled";
-if ($smtp_starttls eq "enabled") { $smtp_starttls = "true"; } elsif ($smtp_starttls eq "disabled") { $smtp_starttls = "false"; }
+my $smtp_port = "587";
+if ($smtp_starttls eq "enabled") { $smtp_starttls = "true"; } elsif ($smtp_starttls eq "disabled") { $smtp_starttls = "false";  $smtp_port = "10587" }
 
 print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.starttls';\n";
 print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.starttls', '$smtp_starttls');\n";
+print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.port';\n";
+print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.port', '$smtp_port');\n";
 
 # Set remote calendar automatic synchronization
 my $remote_calendar_autosync = $db->get_prop('webtop','RemoteCalendarAutosync') || 'enabled';


### PR DESCRIPTION
Set SMTP port to 10587 which is available only from localhost
and support authentication without TLS.

NethServer/dev#6076
NethServer/dev#6079