### PR TITLE
Remove SMTP config based on properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,6 @@ Available properties:
 * ``PbxProvider``: PBX provider name
 * ``PbxProviderNethvoiceWebrestUrl``: NethVoice base url for API calls, used when ``PbxProvider`` is set to ``nethvoice``
 * ``DefaultToolBarIconsSize``: Default dimension of the toolbar icons, available values: ``small``, ``medium``, ``large``. Default is ``medium``
-* ``SmtpAuth``: if set to ``enabled``, it enables authentication for user sessions SMTP send. Default is ``disabled``
-* ``SmtpStarttls``: if set to ``enabled``, it enables STARTTLS SMTP send. Default is ``disabled``
 * ``RemoteCalendarAutosync``: if set to ``enabled``, it enables remote calendars auto-sync functionality. The sincronization interval can be set by user on remote calendar creation. Default is ``enabled``
 * ``RemoteCalendarAutosyncOnlywhenonline``: if set to ``enabled`` the remote calendars is auto-sync only when calendar’s owner is online during the sincronization time. Default is ``disabled``
 * ``RemoteCategoryAutosync``: if set to ``enabled`` , it enables remote categories auto-sync functionality. The sincronization interval can be set by user on remote category creation. Default is ``enabled``

--- a/root/etc/e-smith/db/configuration/defaults/webtop/SmtpAuth
+++ b/root/etc/e-smith/db/configuration/defaults/webtop/SmtpAuth
@@ -1,1 +1,0 @@
-disabled

--- a/root/etc/e-smith/db/configuration/defaults/webtop/SmtpStarttls
+++ b/root/etc/e-smith/db/configuration/defaults/webtop/SmtpStarttls
@@ -1,1 +1,0 @@
-disabled

--- a/root/etc/e-smith/db/configuration/migrate/issue6080
+++ b/root/etc/e-smith/db/configuration/migrate/issue6080
@@ -1,0 +1,13 @@
+{
+    #
+    # issue6080 - remove SMTP properties
+    #
+    
+    use esmith::ConfigDB;
+
+    my $configDb = esmith::ConfigDB->open() || return '';
+    $configDb->get_prop_and_delete('webtop','SmtpAuth');
+    $configDb->get_prop_and_delete('webtop','SmtpStarttls');
+
+    '';
+}

--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
@@ -178,21 +178,6 @@ my $default_toolbar_icons_size = $db->get_prop('webtop','DefaultToolBarIconsSize
 print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'default.viewport.header.scale';\n";
 print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'default.viewport.header.scale', '$default_toolbar_icons_size');\n";
 
-#set SMTP Auth (default false)
-my $smtp_auth = $db->get_prop('webtop','SmtpAuth') || "disabled";
-if ($smtp_auth eq "enabled") { $smtp_auth = "true"; } elsif ($smtp_auth eq "disabled") { $smtp_auth = "false"; }
-
-print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.auth';\n";
-print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.auth', '$smtp_auth');\n";
-
-
-#set SMTP STARTTLS (default false)
-my $smtp_starttls = $db->get_prop('webtop','SmtpStarttls') || "disabled";
-if ($smtp_starttls eq "enabled") { $smtp_starttls = "true"; } elsif ($smtp_starttls eq "disabled") { $smtp_starttls = "false"; }
-
-print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.starttls';\n";
-print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.starttls', '$smtp_starttls');\n";
-
 # Set remote calendar automatic synchronization
 my $remote_calendar_autosync = $db->get_prop('webtop','RemoteCalendarAutosync') || 'enabled';
 if ($remote_calendar_autosync eq "enabled") { $remote_calendar_autosync = "true"; } elsif ($remote_calendar_autosync eq "disabled") { $remote_calendar_autosync = "false"; }

--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
@@ -213,5 +213,17 @@ print $fh "INSERT INTO \"core\".\"settings\" (service_id, key, value) SELECT 'co
 # Change old default SMTP port to the new one
 print $fh "UPDATE \"core\".\"settings\" SET value = '10587' WHERE key = 'smtp.port' AND service_id = 'com.sonicle.webtop.core' AND value = '587'";
 
+# Migrate old SMTP defaults
+my $sonicle_password = NethServer::Password::store('webtop5');
+my $out = `PGPASSWORD=$sonicle_password psql -U sonicle -c "COPY(select value from core.settings where key = 'smtp.host' or key = 'smtp.port') TO STDOUT" webtop5`;
+chomp $out;
+my ($smtp_host,$smtp_port) = split(/\n/,$out);
+if ($smtp_host eq 'localhost' && $smtp_port eq '587') {
+    print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.auth';\n";
+    print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.auth', 'true');\n";
+    print $fh "DELETE FROM \"core\".\"settings\" WHERE service_id = 'com.sonicle.webtop.core' and key = 'smtp.port';\n";
+    print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\") VALUES ('com.sonicle.webtop.core', 'smtp.port', '10587');\n";
+}
+
 # Execute SQL script
 system("su - postgres  -c 'psql webtop5 < ".$fh->filename."' >/dev/null");

--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
@@ -210,5 +210,8 @@ print $fh "INSERT INTO \"core\".\"settings\" (\"service_id\", \"key\", \"value\"
 print $fh "INSERT INTO \"core\".\"settings\" (service_id, key, value) SELECT 'com.sonicle.webtop.contacts', 'default.showby', 'lnfn'
               WHERE NOT EXISTS (SELECT value from \"core\".\"settings\" WHERE key = 'com.sonicle.webtop.contacts' and service_id = 'default.showby');\n";
 
+# Change old default SMTP port to the new one
+print $fh "UPDATE \"core\".\"settings\" SET value = '10587' WHERE key = 'smtp.port' AND service_id = 'com.sonicle.webtop.core' AND value = '587'";
+
 # Execute SQL script
 system("su - postgres  -c 'psql webtop5 < ".$fh->filename."' >/dev/null");

--- a/root/usr/share/webtop/sql/data/init-data-nethserver.sql
+++ b/root/usr/share/webtop/sql/data/init-data-nethserver.sql
@@ -6,7 +6,8 @@ UPDATE "core"."settings" SET value = '' WHERE key = 'dropbox.appsecret' AND serv
 UPDATE "core"."settings" SET value = '' WHERE key = 'googledrive.clientid' AND service_id = 'com.sonicle.webtop.core';
 UPDATE "core"."settings" SET value = '' WHERE key = 'googledrive.clientsecret' AND service_id = 'com.sonicle.webtop.core';
 UPDATE "core"."settings" SET value = '/usr/share/webtop/bin/' WHERE key = 'php.path' AND service_id = 'com.sonicle.webtop.core';
-UPDATE "core"."settings" SET value = '587' WHERE key = 'smtp.port' AND service_id = 'com.sonicle.webtop.core';
+UPDATE "core"."settings" SET value = '10587' WHERE key = 'smtp.port' AND service_id = 'com.sonicle.webtop.core';
+UPDATE "core"."settings" SET value = 'true' WHERE key = 'smtp.auth' AND service_id = 'com.sonicle.webtop.core';
 UPDATE "core"."settings" SET value = '/usr/share/webtop/z-push' WHERE key = 'zpush.path' AND service_id = 'com.sonicle.webtop.core';
 UPDATE "core"."settings" SET value = '/var/lib/nethserver/webtop' WHERE key = 'home.path' AND service_id = 'com.sonicle.webtop.core';
 


### PR DESCRIPTION
NethServer/dev#6080
NethServer/dev#6079

**Implemented changes**

On existing machines configured with SMTP `localhost:587`, the patch must:
- change `smtp.port` from `587` to `10587`
- set `smtp.starttls` to `false`
- set `smtp.auth` to `true`

On new machines:
- set  `smtp.port` to `10587`
- set `smtp.auth` to `true`