### PR TITLE
Update catalina.policy

### DIFF
--- a/root/var/lib/tomcats/webtop/conf/catalina.policy
+++ b/root/var/lib/tomcats/webtop/conf/catalina.policy
@@ -58,7 +58,7 @@ grant codeBase "file:${java.home}/lib/ext/-" {
 grant codeBase "file:/usr/share/java/tomcat-servlet-3.0-api.jar" {
         permission java.security.AllPermission;
 };
-grant codeBase "file:/usr/share/java/omcat-jsp-2.2-api.jar" {
+grant codeBase "file:/usr/share/java/tomcat-jsp-2.2-api.jar" {
         permission java.security.AllPermission;
 };
 grant codeBase "file:/usr/share/java/tomcat-el-2.2-api.jar" {


### PR DESCRIPTION
changed line 61 to point to /usr/share/java/tomcat-jsp.... instead of java/omcat-jsp

Upstream bugs:
- https://bugs.centos.org/view.php?id=14812
- https://bugzilla.redhat.com/show_bug.cgi?id=1448752

Community discussion: https://community.nethserver.org/t/misspelled-tomcat-code-in-catalina-policy/15461