### PR TITLE
systemd: restart the service on failure

### DIFF
--- a/root/etc/systemd/system/tomcat8@.service.d/webtop.conf
+++ b/root/etc/systemd/system/tomcat8@.service.d/webtop.conf
@@ -1,3 +1,4 @@
 [Service]
 StandardOutput=null
 StandardError=null
+Restart=on-failure


### PR DESCRIPTION
Try to restart webtop after it was killed by the kernel or crashed for
an error. This will ensure the continuation of the service after some
temporary events, like a spike in memory usage or high system load.

NethServer/dev#6220