### PR TITLE
httpd: set timeout to 180 for `/webtop` ProxyPass

### DIFF
--- a/root/etc/e-smith/templates/etc/httpd/conf.d/webtop.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/webtop.conf/10base
@@ -14,5 +14,5 @@
 
 ProxyPass /webtop/push ws://127.0.0.1:58080/webtop/push
 ProxyPassReverse /webtop/push ws://127.0.0.1:58080/webtop/push
-ProxyPass /webtop http://127.0.0.1:58080/webtop
+ProxyPass /webtop http://127.0.0.1:58080/webtop timeout=180
 ProxyPassReverse /webtop http://127.0.0.1:58080/webtop


### PR DESCRIPTION
Some WebTop operations can be more longer then usual and for this
a new timout was [introduced](https://issues.sonicle.com/browse/WT-869), but we have also to increase the
timeout of the Apache's ProxyPass for this new timeoute to be effective.

NethServer/dev#6338