### PR TITLE
api & ui. fix app url if virtual host is enabled

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -25,6 +25,7 @@ use warnings;
 use DBI;
 use JSON;
 use NethServer::Password;
+use esmith::ConfigDB;
 
 require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
 
@@ -80,7 +81,10 @@ if ($cmd eq 'configuration') {
   }
   
   $ret->{'configuration'}{'admin_pass_warn'} = $warn;
-  
+
+  # get virtualhost from configuration
+  my $db = esmith::ConfigDB->open_ro();
+  $ret->{'configuration'}{'VirtualHost'} = $db->get_prop('webtop', 'VirtualHost');
 } else {
     error();
 }

--- a/api/read
+++ b/api/read
@@ -24,7 +24,12 @@ input=$(cat)
 action=$(jq -r .action <<<"$input")
 protocol=$(jq -r .location.protocol <<<"$input")
 host=$(jq -r .location.hostname <<<"$input")
+virtualhost=$(/sbin/e-smith/config getprop webtop VirtualHost)
 
 if [[ $action == "app-info" ]]; then
-    printf '{"url":"%s"}' "${protocol}//${host}/webtop"
+    if [[ -z "$virtualhost" ]]; then
+        printf '{"url":"%s"}' "${protocol}//${host}/webtop"
+    else
+        printf '{"url":"%s"}' "${protocol}//${virtualhost}"
+    fi
 fi

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -26,7 +26,7 @@
           </div>
           <a
             target="_blank"
-            :href="configuration.public_url"
+            :href="configuration.app_url"
             class="btn btn-primary btn-lg open-app"
           >{{$t('dashboard.open_app')}}</a>
         </div>
@@ -79,7 +79,7 @@ export default {
       configuration: {
         active_users: 0,
         version: {},
-        public_url: null,
+        app_url: null,
         admin_pass_warn: false
       }
     };
@@ -109,7 +109,11 @@ export default {
             });
             context.configuration.version = sorted;
             
-            context.configuration.public_url = "http://" + window.location.host.split(":")[0] + "/webtop";
+            if (context.configuration.VirtualHost) {
+              context.configuration.app_url = "https://" + context.configuration.VirtualHost;
+            } else {
+              context.configuration.app_url = "http://" + window.location.host.split(":")[0] + "/webtop";
+            }
           } catch (e) {
             console.error(e);
           }


### PR DESCRIPTION
If e-smith property `webtop VirtualHost` is defined, use it to build app URL instead of default `http://servername/webtop`

NethServer/dev#6398