### PR TITLE
Create `tablefunc` postgresql's extension

### DIFF
--- a/nethserver-webtop5.spec
+++ b/nethserver-webtop5.spec
@@ -16,6 +16,7 @@ Requires: perl-libintl, perl-DBD-Pg
 Requires: webtop5 >= 1.4.15, webtop5-zpush, webtop5-webdav
 Requires: tomcat8, java-1.8.0-openjdk
 Requires: nethserver-rh-php72-php-fpm
+Requires: postgresql-contrib
 
 BuildRequires: perl, java-1.8.0-openjdk-devel
 BuildRequires: nethserver-devtools

--- a/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
+++ b/root/etc/e-smith/events/actions/nethserver-webtop5-conf-db
@@ -110,6 +110,9 @@ print $fh $query;
 print $fh "DELETE FROM \"core\".\"media_types\" WHERE extension = 'zip' AND media_type = 'application/zip';\n";
 print $fh "INSERT INTO \"core\".\"media_types\" (\"extension\", \"media_type\") VALUES ('zip', 'application/zip');\n";
 
+# Create tablefunc extension if not already exist
+print $fh "CREATE EXTENSION IF NOT EXISTS tablefunc;\n";
+
 # Set also public url
 my $public_url_or_vhost = '';
 


### PR DESCRIPTION
The extension tablefunc is used by the new auth log introduced by WebTop
`5.11.0`, so we need to make sure that is enabled in the Postgresql database.

NethServer/dev#6463