### PR TITLE
httpd: remove `X-Forwarded-For` from requests

### DIFF
--- a/root/var/www/html/webtop/.htaccess
+++ b/root/var/www/html/webtop/.htaccess
@@ -2,6 +2,8 @@
 # WebTop .htaccess configuration
 #
 
+RequestHeader unset X-Forwarded-For
+
 RewriteEngine on
 RewriteCond %{HTTP:Upgrade} websocket [NC]
 RewriteCond %{HTTP:Connection} upgrade [NC]


### PR DESCRIPTION
Remove the header `X-Forwarded-For` from the request before send to the
apache's proxy module, otherwise an attacker can send a request whit a
manually forged header and in this way spoof his IP in the WebTop's auth
log.

NethServer/dev#6463