### PR TITLE
htaccess. fix websocket rewrite rule

### DIFF
--- a/root/var/www/html/webtop/.htaccess
+++ b/root/var/www/html/webtop/.htaccess
@@ -7,7 +7,7 @@ RequestHeader unset X-Forwarded-For
 RewriteEngine on
 RewriteCond %{HTTP:Upgrade} websocket [NC]
 RewriteCond %{HTTP:Connection} upgrade [NC]
-RewriteRule .* ws://127.0.0.1:58080/webtop/push%{REQUEST_URI} [P,L]
+RewriteRule .* ws://127.0.0.1:58080%{REQUEST_URI} [P,L]
 
 RewriteEngine on
 RewriteCond %{REQUEST_URI} !/webtop/index.*


### PR DESCRIPTION
Fixed the Rewrite Rule on websocket path that causes problems on websocket use (e.g. session timeout, not working notifications).
Refer to https://github.com/NethServer/dev/issues/6463