### PR TITLE
Explicit enable of secure cookie http header

### DIFF
--- a/root/etc/e-smith/templates/etc/webtop/webtop.properties/10base
+++ b/root/etc/e-smith/templates/etc/webtop/webtop.properties/10base
@@ -4,3 +4,4 @@ webtop.log.dir=/var/log/webtop
 webtop.log.file.basename=webtop
 webtop.log.file.policy=simple
 webtop.log.auth.target=file
+webtop.session.forcesecurecookie=true


### PR DESCRIPTION
From WebTop version < 5.18.2 the HTTP header Set-Cookie is no more added to the requests, this for allow WebTop to be accessible also from not HTTPS connections.
To restore the previous behavior, the property `webtop.session.forcesecurecookie` must be set to `true`.

NethServer/dev#6701